### PR TITLE
get locale from store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-translate",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "main": "lib/index.js",
   "typings": "lib/index",
   "repository": "git@github.com:blueberryapps/ts-translate.git",

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -105,7 +105,7 @@ export class Translator {
     const defaultFormat = this.__findTranslation(['formats'].concat(['date', 'default', 'format']));
     const format = (keywordFormat || customFormat || defaultFormat || defaultFormats.formats.date.default.format) as string;
 
-    return formatDate(givenDate, this.locale, format);
+    return formatDate(givenDate, this.__locale(), format);
   }
 
   formatNumber: FormatNumber = (givenNumber, options) => {


### PR DESCRIPTION
Hello.
In case we use ts-translate with redux, invoking formatDate use **locale** from default settings. not from redux-store.
![image](https://user-images.githubusercontent.com/15861798/51853230-76cc1780-2330-11e9-8e10-80df5a976e51.png)

 