### PR TITLE
Remove deprecated React lifecycle methods

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -35,7 +35,7 @@ export class Provider extends React.Component<ProviderProps, ProviderState> { //
     translator: () => {},
   };
 
-  componentWillMount() {
+  componentDidMount() {
     this.setState({
       historyUnsubscribe: this.props.history ? this.props.history.listen(this.updateLocation) : undefined,
     });
@@ -47,7 +47,7 @@ export class Provider extends React.Component<ProviderProps, ProviderState> { //
     }
   }
 
-  componentWillUpdate(nextProps: ProviderProps) {
+  componentDidUpdate(nextProps: ProviderProps) {
     if (nextProps.pathname && this.connector && nextProps.pathname !== this.props.pathname) {
       this.connector.updateLocation(nextProps.pathname);
     }

--- a/src/editor/TranslationEditor.tsx
+++ b/src/editor/TranslationEditor.tsx
@@ -72,7 +72,7 @@ export class TranslationEditor extends React.PureComponent<TranslationEditorProp
     unsubscribeStore: () => {},
   };
 
-  componentWillMount() {
+  componentDidMount() {
     const { store, translator } = this.context;
 
     const historyUnsubscribe = this.props.history ? this.props.history.listen(this.updateState) : undefined;

--- a/src/translate.tsx
+++ b/src/translate.tsx
@@ -51,7 +51,7 @@ export function translate<P>(scope?: string | string[], overrides?: MsgOptions):
         translator: PropTypes.object,
       };
 
-      componentWillMount() {
+      componentDidMount() {
         const { store } = this.context;
         if (!store) {
           return;


### PR DESCRIPTION
Due to architecture changes in React 16, componentWillMount and componentWillUpdate are now deprecated. Those methods are used a couple of times in the project and the browser console is full of warnings because of them. I successfully tested the changes in this PR in my project and had no issues whatsoever. Please, accept the changes and include them in the next npm release. 